### PR TITLE
Let’s run some tests...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+cache: pip
+python:
+    - 2.7
+    - 3.6
+    #- nightly
+    #- pypy
+    #- pypy3
+matrix:
+    allow_failures:
+        - python: nightly
+        - python: pypy
+        - python: pypy3
+install:
+    #- pip install -r requirements.txt
+    - pip install flake8  # pytest  # add another testing frameworks later
+before_script:
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+    - true  # pytest --capture=sys  # add other tests here
+notifications:
+    on_success: change
+    on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
The Travis Continuous Integration service is free for all open source projects like this one. This configuration will enable Travis CI to run flake8 tests on all pull requests before they are reviewed. This allows contributors and maintainers to make sure no errors are introduced. The owner of this repo would need to go to https://travis-ci.org/profile (log in via GitHub id) and flip the repository switch on to enable free, automated flake8 testing of each pull request.

flake8 testing of https://github.com/jasonkuster/merge-bot on Python 3.6.4

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./mergebot.py:22:28: E999 SyntaxError: invalid syntax
    print 'Caught {signal}.'.format(signal=signum)
                           ^
1     E999 SyntaxError: invalid syntax
```